### PR TITLE
Enhance persona navigation and improve team selection logic

### DIFF
--- a/app/src/modules/nav.py
+++ b/app/src/modules/nav.py
@@ -56,6 +56,39 @@ def AdminPageNav():
     )
 
 
+def SuperfanNav():
+    """Sidebar links for the Superfan persona."""
+    st.sidebar.page_link("pages/10_Superfan_Home.py", label="Superfan Home", icon="🏀")
+    st.sidebar.page_link("pages/11_Player_Finder.py", label="Player Finder", icon="🔎")
+    st.sidebar.page_link("pages/12_Player_Comparison.py", label="Compare Players", icon="⚖️")
+    st.sidebar.page_link("pages/13_Historical_Game_Results.py", label="Game Results", icon="📊")
+
+
+def DataEngineerNav():
+    """Sidebar links for the Data Engineer persona."""
+    st.sidebar.page_link("pages/20_Data_Engineer_Home.py", label="Data Engineer Home", icon="🛠️")
+    st.sidebar.page_link("pages/21_Data_Pipelines.py", label="Data Pipelines", icon="🔁")
+    st.sidebar.page_link("pages/22_System_Health.py", label="System Health", icon="❤️")
+    st.sidebar.page_link("pages/23_Data_Cleanup.py", label="Data Cleanup", icon="🧹")
+
+
+def HeadCoachNav():
+    """Sidebar links for the Head Coach persona."""
+    st.sidebar.page_link("pages/30_Head_Coach_Home.py", label="Head Coach Home", icon="🎯")
+    st.sidebar.page_link("pages/31_Scouting_Reports.py", label="Scouting Reports", icon="📝")
+    st.sidebar.page_link("pages/32_Lineup_Analysis.py", label="Lineup Analysis", icon="🧩")
+    st.sidebar.page_link("pages/33_Season_Summaries.py", label="Season Summaries", icon="📚")
+    st.sidebar.page_link("pages/34_Player_Matchup.py", label="Player Matchup", icon="🤼")
+
+
+def GeneralManagerNav():
+    """Sidebar links for the General Manager persona."""
+    st.sidebar.page_link("pages/40_General_Manager_Home.py", label="General Manager Home", icon="🏢")
+    st.sidebar.page_link("pages/41_Player_Progress.py", label="Player Progress", icon="📈")
+    st.sidebar.page_link("pages/42_Draft_Rankings.py", label="Draft Rankings", icon="🧾")
+    st.sidebar.page_link("pages/43_Contract_Efficiency.py", label="Contract Efficiency", icon="💼")
+
+
 # --------------------------------Links Function -----------------------------------------------
 def SideBarLinks(show_home=False):
     """
@@ -93,8 +126,22 @@ def SideBarLinks(show_home=False):
         if st.session_state["role"] == "administrator":
             AdminPageNav()
 
-    # Always show the About page at the bottom of the list of links
-    AboutPageNav()
+        # Persona-specific tabs
+        if st.session_state.get("role") == "superfan":
+            SuperfanNav()
+
+        if st.session_state.get("role") == "data_engineer":
+            DataEngineerNav()
+
+        if st.session_state.get("role") == "head_coach":
+            HeadCoachNav()
+
+        if st.session_state.get("role") == "general_manager":
+            GeneralManagerNav()
+
+    # Show the About page only when no user is logged in
+    if not st.session_state.get("authenticated", False):
+        AboutPageNav()
 
     if st.session_state["authenticated"]:
         # Always show a logout button if there is a logged in user

--- a/app/src/pages/31_Scouting_Reports.py
+++ b/app/src/pages/31_Scouting_Reports.py
@@ -35,18 +35,95 @@ def make_request(endpoint, method='GET', data=None):
 teams_data = make_request("/basketball/teams")
 if teams_data and 'teams' in teams_data:
     team_names = [team['name'] for team in teams_data['teams']]
-    
-    your_team = st.selectbox("Select Your Team:", team_names)
+
+    # Try to determine the user's team from session state. Map known users to their team.
+    default_team_map = {
+        # Head Coach & GM example
+        'Marcus': 'Brooklyn Nets',
+        'Andre': 'Brooklyn Nets',
+        # other known first names can be added here
+        'Mike': None,
+        'Johnny': None
+    }
+
+    # Determine the user's team using a unique identifier if available (scalable)
+    # Prefer a unique id in session_state (e.g. 'user_id', 'username', or 'user_key').
+    user_identifier = (
+        st.session_state.get('user_id')
+        or st.session_state.get('username')
+        or st.session_state.get('user_key')
+    )
+
+    default_team_name = None
+
+    # If the logged-in user is the head coach, prefer a first-name mapping to auto-select their team
+    if st.session_state.get('role') == 'head_coach':
+        headcoach_firstname_map = {
+            'Marcus': 'Brooklyn Nets'
+        }
+        fn = st.session_state.get('first_name')
+        if fn and fn in headcoach_firstname_map:
+            default_team_name = headcoach_firstname_map[fn]
+
+    # 1) If we have a unique identifier, try to fetch the user's profile from the backend
+    if user_identifier:
+        user_profile = make_request(f"/users/{user_identifier}")
+        if user_profile:
+            # Accept several possible shapes returned by the API
+            if isinstance(user_profile, dict):
+                if user_profile.get('team_name'):
+                    default_team_name = user_profile.get('team_name')
+                elif user_profile.get('team') and isinstance(user_profile.get('team'), dict):
+                    default_team_name = user_profile['team'].get('name')
+                elif user_profile.get('team_id'):
+                    # convert id to name using teams_data
+                    tid = user_profile.get('team_id')
+                    default_team_name = next((t['name'] for t in teams_data['teams'] if t['team_id'] == tid), None)
+
+    # 2) Fallback to a hardcoded mapping keyed by a unique identifier (extendable)
+    if not default_team_name and user_identifier:
+        default_id_map = {
+            # use stable unique keys (e.g. usernames or ids) here
+            'marcus_thompson': 'Brooklyn Nets',
+            'andre_wu': 'Brooklyn Nets'
+        }
+        default_team_name = default_id_map.get(user_identifier)
+
+    # 3) Last-resort fallback to the legacy first_name mapping but warn it's not ideal
+    if not default_team_name:
+        first_name = st.session_state.get('first_name')
+        if first_name:
+            fallback_map = {
+                'Marcus': 'Brooklyn Nets',
+                'Andre': 'Brooklyn Nets'
+            }
+            default_team_name = fallback_map.get(first_name)
+            if default_team_name:
+                st.warning('Using first-name fallback to determine your team. Consider logging in with a unique user identifier for a more reliable experience.')
+
+    your_team_id = None
+
+    if default_team_name and default_team_name in team_names:
+        # Display the inferred team and use its id
+        st.write(f"Your Team: {default_team_name}")
+        your_team_id = next((team['team_id'] for team in teams_data['teams'] if team['name'] == default_team_name), None)
+    else:
+        # Fall back to allowing the user to pick their team
+        your_team = st.selectbox("Select Your Team:", team_names)
+        your_team_id = next((team['team_id'] for team in teams_data['teams'] if team['name'] == your_team), None)
+
+    # Always select an opponent to scout
     selected_opponent = st.selectbox("Select a team to scout:", team_names)
 
     if st.button("Get Scouting Report"):
-        your_team_id = [team['team_id']
-                        for team in teams_data['teams'] if team['name'] == your_team][0]
-        opponent_id = [team['team_id']
-                       for team in teams_data['teams'] if team['name'] == selected_opponent][0]
-        
-        report_data = make_request(
-            f"/analytics/opponent-reports?team_id={your_team_id}&opponent_id={opponent_id}")
+        if your_team_id is None:
+            st.error("Could not determine your team. Please select your team.")
+        else:
+            opponent_id = [team['team_id']
+                           for team in teams_data['teams'] if team['name'] == selected_opponent][0]
+
+            report_data = make_request(
+                f"/analytics/opponent-reports?team_id={your_team_id}&opponent_id={opponent_id}")
 
         if report_data:
             st.subheader(f"Scouting Report: {selected_opponent}")


### PR DESCRIPTION
Added persona-specific sidebar navigation for Superfan, Data Engineer, Head Coach, and General Manager roles. Improved team selection logic in Scouting Reports to infer the user's team from session state or backend profile, with robust fallbacks. Enhanced Lineup Analysis with better error handling and debug output for API responses. Refactored player matchup query to use PlayerMatchup bridge table and support both offensive/defensive roles, with season filtering and normalized output.